### PR TITLE
Refactor: Separate taskReducer and types into own files

### DIFF
--- a/src/pages/TaskList/TaskList.tsx
+++ b/src/pages/TaskList/TaskList.tsx
@@ -24,7 +24,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import SortableTask from '@/components/SortableTask';
-import { Task, TaskAction } from '@/types/task';
+import { Task } from '@/types/task';
 import { taskReducer } from '@/reducers/taskReducer';
 
 const supabase = createClient();

--- a/src/pages/TaskList/TaskList.tsx
+++ b/src/pages/TaskList/TaskList.tsx
@@ -24,75 +24,10 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import SortableTask from '@/components/SortableTask';
+import { Task, TaskAction } from '@/types/task';
+import { taskReducer } from '@/reducers/taskReducer';
 
 const supabase = createClient();
-
-// Task型の定義
-interface Task {
-  id: string;
-  user_id: string;
-  title: string;
-  description: string;
-  estimated_minute: number | null;
-  task_order: number | null;
-  start_time: string | null;
-  end_time: string | null;
-  created_at: string;
-  task_date: string;
-}
-
-// Action Types
-type SetTasksAction = {
-  type: 'SET_TASKS';
-  payload: Task[];
-};
-
-type AddTaskAction = {
-  type: 'ADD_TASK';
-  payload: Task;
-};
-
-type UpdateTaskAction = {
-  type: 'UPDATE_TASK';
-  payload: Partial<Task> & { id: string }; // Requires id, and allows partial updates to other fields
-};
-
-type DeleteTaskAction = {
-  type: 'DELETE_TASK';
-  payload: string; // Task id
-};
-
-type ReorderTasksAction = {
-  type: 'REORDER_TASKS';
-  payload: Task[]; // The new ordered array of tasks
-};
-
-type TaskAction =
-  | SetTasksAction
-  | AddTaskAction
-  | UpdateTaskAction
-  | DeleteTaskAction
-  | ReorderTasksAction;
-
-// Task Reducer
-const taskReducer = (state: Task[], action: TaskAction): Task[] => {
-  switch (action.type) {
-    case 'SET_TASKS':
-      return action.payload;
-    case 'ADD_TASK':
-      return [action.payload, ...state]; // Adds new task to the beginning
-    case 'UPDATE_TASK':
-      return state.map(task =>
-        task.id === action.payload.id ? { ...task, ...action.payload } : task
-      );
-    case 'DELETE_TASK':
-      return state.filter(task => task.id !== action.payload);
-    case 'REORDER_TASKS':
-      return action.payload;
-    default:
-      return state;
-  }
-};
 
 // 編集中のフィールドの型
 interface EditingField {

--- a/src/reducers/taskReducer.ts
+++ b/src/reducers/taskReducer.ts
@@ -1,0 +1,21 @@
+import { Task, TaskAction } from '@/types/task';
+
+// Task Reducer
+export const taskReducer = (state: Task[], action: TaskAction): Task[] => {
+  switch (action.type) {
+    case 'SET_TASKS':
+      return action.payload;
+    case 'ADD_TASK':
+      return [action.payload, ...state]; // Adds new task to the beginning
+    case 'UPDATE_TASK':
+      return state.map(task =>
+        task.id === action.payload.id ? { ...task, ...action.payload } : task
+      );
+    case 'DELETE_TASK':
+      return state.filter(task => task.id !== action.payload);
+    case 'REORDER_TASKS':
+      return action.payload;
+    default:
+      return state;
+  }
+};

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,46 @@
+// Task型の定義
+export interface Task {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  estimated_minute: number | null;
+  task_order: number | null;
+  start_time: string | null;
+  end_time: string | null;
+  created_at: string;
+  task_date: string;
+}
+
+// Action Types
+export type SetTasksAction = {
+  type: 'SET_TASKS';
+  payload: Task[];
+};
+
+export type AddTaskAction = {
+  type: 'ADD_TASK';
+  payload: Task;
+};
+
+export type UpdateTaskAction = {
+  type: 'UPDATE_TASK';
+  payload: Partial<Task> & { id: string }; // Requires id, and allows partial updates to other fields
+};
+
+export type DeleteTaskAction = {
+  type: 'DELETE_TASK';
+  payload: string; // Task id
+};
+
+export type ReorderTasksAction = {
+  type: 'REORDER_TASKS';
+  payload: Task[]; // The new ordered array of tasks
+};
+
+export type TaskAction =
+  | SetTasksAction
+  | AddTaskAction
+  | UpdateTaskAction
+  | DeleteTaskAction
+  | ReorderTasksAction;


### PR DESCRIPTION
- Moved Task interface and TaskAction related types to `src/types/task.ts`.
- Moved taskReducer function to `src/reducers/taskReducer.ts`.
- Updated `src/pages/TaskList/TaskList.tsx` to import types and reducer from their new locations.

This change improves code organization and maintainability without altering functionality.