### PR TITLE
Refactor: Centralize Supabase user fetching with React Context

### DIFF
--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,37 +1,16 @@
-import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { createClient } from '@/lib/supabase/client'
-
-const supabase = createClient()
+import { useSupabaseUser } from '@/lib/supabase/hooks/useSupabaseUser'
 
 const RequireAuth = ({ children }: { children: React.ReactNode }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    const checkAuth = async () => {
-      const { data } = await supabase.auth.getUser()
-      setIsAuthenticated(!!data.user)
-    }
-
-    checkAuth()
-
-    // 認証状態の変更を監視
-    const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
-      setIsAuthenticated(!!session)
-    })
-
-    return () => {
-      authListener.subscription.unsubscribe()
-    }
-  }, [])
+  const { user, isLoading } = useSupabaseUser()
 
   // 認証状態チェック中は何も表示しない
-  if (isAuthenticated === null) {
+  if (isLoading) {
     return null
   }
 
   // 未認証の場合はログインページにリダイレクト
-  if (!isAuthenticated) {
+  if (!user) {
     return <Navigate to="/login" replace />
   }
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, useState, useEffect, ReactNode } from 'react';
+import { User } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/client';
+
+const supabase = createClient();
+
+interface UserContextType {
+  user: User | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchUserSession = async () => {
+      setIsLoading(true);
+      try {
+        const { data: { user: currentUser }, error: fetchError } = await supabase.auth.getUser();
+        if (fetchError) {
+          throw fetchError;
+        }
+        setUser(currentUser);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserSession();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+      setUser(session?.user ?? null);
+      setIsLoading(false); // Set loading to false on auth state change
+    });
+
+    return () => {
+      if (authListener?.subscription) {
+        authListener.subscription.unsubscribe();
+      }
+    };
+  }, []);
+
+  return (
+    <UserContext.Provider value={{ user, isLoading, error }}>
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/src/lib/supabase/hooks/useSupabaseUser.ts
+++ b/src/lib/supabase/hooks/useSupabaseUser.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { UserContext } from '../../../contexts/UserContext'; // Adjusted path
+
+// The UseSupabaseUserReturn interface is implicitly defined by UserContextType, so it's removed.
+// Also removing User from @supabase/supabase-js and createClient as they are no longer used here.
+
+export const useSupabaseUser = () => {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error('useSupabaseUser must be used within a UserProvider');
+  }
+  return context; // This will return { user, isLoading, error }
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './styles/globals.css'
+import { UserProvider } from './contexts/UserContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <UserProvider>
+        <App />
+      </UserProvider>
     </BrowserRouter>
   </React.StrictMode>,
 )

--- a/src/pages/IntegrationKeys.tsx
+++ b/src/pages/IntegrationKeys.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { PlusCircle, Trash2, RefreshCw, Copy, CheckCircle, XCircle } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
+import { useSupabaseUser } from '@/lib/supabase/hooks/useSupabaseUser';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
@@ -11,6 +12,7 @@ import type { IntegrationKey } from '@/types/integration-key';
 const supabase = createClient();
 
 const IntegrationKeysPage = () => {
+  const { user } = useSupabaseUser();
   const [keys, setKeys] = useState<IntegrationKey[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [newKeyName, setNewKeyName] = useState('');
@@ -57,8 +59,16 @@ const IntegrationKeysPage = () => {
     }
 
     // ユーザー情報を取得
-    const { data: userData } = await supabase.auth.getUser();
-    const userId = userData.user?.id;
+    const userId = user?.id;
+
+    if (!userId) {
+      toast({
+        variant: 'destructive',
+        title: 'エラー',
+        description: 'ユーザー情報が取得できませんでした。再度ログインしてください。',
+      });
+      return;
+    }
 
     setIsCreating(true);
     try {
@@ -70,7 +80,7 @@ const IntegrationKeysPage = () => {
         .insert({
           name: newKeyName.trim(),
           key: keyString,
-          user_id: userId,
+          user_id: userId, // userId is now from the hook
           is_active: true,
         });
 

--- a/src/pages/TaskList/TaskList.tsx
+++ b/src/pages/TaskList/TaskList.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Calendar } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
+import { useSupabaseUser } from '@/lib/supabase/hooks/useSupabaseUser';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/use-toast';
 import { Calendar as CalendarComponent } from '@/components/ui/calendar';
@@ -36,6 +37,7 @@ interface EditingField {
 }
 
 const TaskList = () => {
+  const { user } = useSupabaseUser();
   const [tasks, dispatch] = useReducer(taskReducer, []);
   const [isLoading, setIsLoading] = useState(true);
   const [editingField, setEditingField] = useState<EditingField | null>(null);
@@ -227,8 +229,7 @@ const TaskList = () => {
     setIsAddingTask(true);
 
     // ユーザー情報を取得
-    const { data: userData } = await supabase.auth.getUser();
-    const userId = userData.user?.id;
+    const userId = user?.id;
 
     if (!userId) {
       toast({


### PR DESCRIPTION
I replaced multiple direct calls to `supabase.auth.getUser()` with a centralized approach using React Context and a custom hook (`useSupabaseUser`).

Key changes:
- I created `UserContext` and `UserProvider` (`src/contexts/UserContext.tsx`) to fetch, store, and provide user data and authentication state globally.
- I wrapped the application with `UserProvider` in `src/main.tsx`.
- I modified the `useSupabaseUser` hook (`src/lib/supabase/hooks/useSupabaseUser.ts`) to consume `UserContext`, removing its direct Supabase calls.
- Components (`RequireAuth.tsx`, `TaskList.tsx`, `IntegrationKeys.tsx`) now receive user data efficiently via the updated hook and context.

This change addresses the issue of potentially redundant user data fetches across different parts of the application, improving efficiency and maintainability.