### PR TITLE
Fix: Allow users to read their integration keys and prevent race cond…

### DIFF
--- a/src/pages/IntegrationKeys.tsx
+++ b/src/pages/IntegrationKeys.tsx
@@ -44,8 +44,10 @@ const IntegrationKeysPage = () => {
 
   // 初回ロード時にキーを取得
   useEffect(() => {
-    fetchKeys();
-  }, []);
+    if (user) {
+      fetchKeys();
+    }
+  }, [user]);
 
   // 新しいキーを生成する
   const handleGenerateKey = async (e: React.FormEvent) => {

--- a/supabase/migrations/20250523084637_add_select_rls_to_integration_keys.sql
+++ b/supabase/migrations/20250523084637_add_select_rls_to_integration_keys.sql
@@ -1,0 +1,6 @@
+-- Users can read their own integration keys
+create policy "Users can read their own integration keys"
+on public.integration_keys
+for select
+to authenticated
+using (auth.uid() = user_id);

--- a/supabase/schemas/integration_keys.sql
+++ b/supabase/schemas/integration_keys.sql
@@ -39,6 +39,13 @@ for delete
 to authenticated
 using (auth.uid() = user_id);
 
+-- Users can read their own integration keys
+create policy "Users can read their own integration keys"
+on public.integration_keys
+for select
+to authenticated
+using (auth.uid() = user_id);
+
 -- コメント
 comment on table public.integration_keys is 'インテグレーションキー管理テーブル';
 comment on column public.integration_keys.id is 'インテグレーションキーの一意識別子';


### PR DESCRIPTION
…ition

This commit addresses an issue where you could not retrieve your integration keys.

The primary cause was a missing Row Level Security (RLS) policy for 'select' operations on the 'integration_keys' table. This commit adds a new policy ("Users can read their own integration keys") that permits authenticated users to select keys where the 'user_id' matches their own 'auth.uid()'. This policy has been added to the schema definition and a new database migration file.

Additionally, a potential race condition in `IntegrationKeysPage.tsx` has been resolved. The `useEffect` hook responsible for fetching keys was updated to only execute when the `user` object is available and to re-fetch if the `user` changes. This ensures that the query is always made with a valid `user_id`.