### PR TITLE
fix: Revert environment variable name to X_INTEGRATION_ID

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,122 @@
+# MCP Server (Node.js)
+
+This server implements the Model Context Protocol (MCP) using the `@modelcontextprotocol/sdk` for Node.js. It is intended to interact with the Supabase `task-management` Edge Function.
+
+## Purpose
+
+The server uses `StdioServerTransport`, meaning it communicates over standard input/output. The primary goal is to expose MCP capabilities (like Tools) that allow clients to interact with the Supabase `task-management` function. For example, an MCP client could invoke a tool on this server, which would then trigger an HTTP POST request to the Supabase function.
+
+Technically, the server implements handlers for standard MCP requests (like listing tools and calling tools). It advertises the `create_task` tool with its input parameter schema (derived from Zod) when queried by an MCP client.
+
+## Setup and Running
+
+1.  **Prerequisites**:
+    *   Ensure you have [Node.js](https://nodejs.org/) installed (which includes npm).
+    *   The Supabase stack (including the `task-management` function) should be running if you intend to test interactions with it.
+
+2.  **Navigate to the directory**:
+    ```bash
+    cd /path/to/your/project/mcp
+    ```
+
+3.  **Install Dependencies**:
+    If you haven't already, or if you've pulled this fresh:
+    ```bash
+    npm install
+    ```
+
+4.  **Set Environment Variables**:
+    Before running the server, you **must** set the environment variables detailed below.
+    Example:
+    ```bash
+    export SUPABASE_FUNCTION_URL="http://localhost:54321/functions/v1/task-management"
+    export X_INTEGRATION_ID="your-actual-integration-id"
+    ```
+
+5.  **Running the Server**:
+    The server is written in TypeScript and can be run using `ts-node`:
+    ```bash
+    # Ensure environment variables are set as shown above
+    npx ts-node index.ts
+    ```
+    Alternatively, you can compile the TypeScript to JavaScript using `tsc` (as per `tsconfig.json` settings which outputs to `./dist`) and then run the JavaScript file:
+    ```bash
+    # Ensure environment variables are set
+    npm run build  # This uses the "build": "tsc" script in package.json
+    node dist/index.js
+    ```
+    For simplicity during development, `ts-node` is often preferred.
+
+    Upon starting, you should see messages indicating the Supabase URL and Integration ID being used, followed by: `"[timestamp] MCP Server with StdioTransport started. Ready to handle ListTools and CallTool requests."` (The actual tool name `create_task` is advertised via the ListTools handler).
+
+## Environment Variables (Required)
+
+The following environment variables **must** be set before running the server:
+
+*   **`SUPABASE_FUNCTION_URL`**: Specifies the full URL of the target Supabase `task-management` Edge Function.
+    *   Example: `export SUPABASE_FUNCTION_URL="http://localhost:54321/functions/v1/task-management"`
+    *   For a deployed Supabase function, use its production URL.
+
+*   **`X_INTEGRATION_ID`**: The Integration ID required by the Supabase `task-management` function for authentication and authorization. This ID is used by the Supabase function to identify and authorize the calling user or system.
+    *   Example: `export X_INTEGRATION_ID="your-actual-integration-id"`
+
+The server will log an error and exit if these variables are not detected at startup.
+
+## Interaction Model
+
+The `task-management` Supabase function is an HTTP endpoint that expects `POST` requests with a JSON body and an `x-integration-id` header (note: the header sent to Supabase remains `x-integration-id`).
+
+This MCP server exposes its functionality through an MCP Tool named `create_task`.
+
+### Tool: `create_task(params)`
+
+**Parameters (`params` object):**
+*   `title` (string): The title of the task. **Required**.
+*   `description` (string, optional): A description for the task.
+*   `estimated_minute` (number, optional): Estimated time in minutes for the task.
+*   `task_date` (string, optional): The date for the task in "YYYY-MM-DD" format. If not provided, the Supabase function typically defaults to the current date.
+
+When an MCP client invokes this tool (e.g., over the stdio transport), the server will:
+1.  Use the `title`, `description`, `estimated_minute`, and `task_date` from the `params` to construct the JSON body for the HTTP request.
+2.  Retrieve the `SUPABASE_FUNCTION_URL` (to know where to send the request) and `X_INTEGRATION_ID` (for the `x-integration-id` header) from the environment variables.
+3.  Make an HTTP `POST` request to the configured `SUPABASE_FUNCTION_URL`.
+4.  Return the JSON response (which could be a success object or an error object) from the Supabase function directly back to the MCP client.
+
+This allows MCP clients to manage tasks in Supabase without needing to handle HTTP requests or manage Supabase-specific authentication details directly.
+
+## Example MCP Client Configuration
+
+This section provides an example of how this MCP server could be configured in an MCP client application (e.g., a desktop assistant that supports MCP). The exact format may vary by client.
+
+```json
+{
+  "mcpServers": {
+    "myTaskServer": {
+      "command": "node",
+      "args": [
+        "/path/to/your/project/mcp/dist/index.js"
+      ],
+      "env": {
+        "X_INTEGRATION_ID": "your-actual-integration-id-value",
+        "SUPABASE_FUNCTION_URL": "https://<your-project-ref>.supabase.co/functions/v1/task-management"
+      }
+    }
+  }
+}
+```
+
+**Notes on Client Configuration:**
+
+*   **`myTaskServer`**: This is a client-defined alias for this MCP server instance. The client will use this name to direct MCP requests.
+*   **`command` and `args`**:
+    *   These fields specify how to launch the MCP server.
+    *   The example `["node", "/path/to/your/project/mcp/dist/index.js"]` assumes you have built the TypeScript to JavaScript using `npm run build` and are running the compiled output.
+    *   Alternatively, for development or if `ts-node` is globally available and preferred, you might use `["npx", "ts-node", "/path/to/your/project/mcp/index.ts"]`.
+    *   Ensure the path to `index.js` or `index.ts` is correct for your system.
+*   **`env`**:
+    *   This block is crucial for passing the required environment variables to the server process.
+    *   `X_INTEGRATION_ID`: Must be set to your specific integration ID.
+    *   `SUPABASE_FUNCTION_URL`: Must be set to the URL of your Supabase `task-management` function.
+    *   Include any other environment variables your server might need in the future.
+
+This configuration allows the MCP client to start and communicate with your MCP server, which then acts as a bridge to your Supabase function.

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -1,0 +1,175 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import fetch from 'node-fetch'; // Using node-fetch v2
+import { z } from 'zod';
+import zodToJsonSchema from 'zod-to-json-schema';
+
+// Environment variable checks
+const supabaseFunctionUrl = process.env.SUPABASE_FUNCTION_URL;
+const integrationId = process.env.X_INTEGRATION_ID;
+
+if (!supabaseFunctionUrl) {
+  console.error("FATAL: SUPABASE_FUNCTION_URL environment variable is not set.");
+  process.exit(1);
+}
+if (!integrationId) {
+  console.error("FATAL: X_INTEGRATION_ID environment variable is not set.");
+  process.exit(1);
+}
+
+console.log(`MCP Server configured to use Supabase URL: ${supabaseFunctionUrl}`);
+console.log(`MCP Server configured to use Integration ID: ${integrationId}`);
+
+const transport = new StdioServerTransport();
+const server = new McpServer(transport);
+
+// Interface for task parameters (kept for clarity, matches the schema)
+interface CreateTaskParams {
+  title: string;
+  description?: string;
+  estimated_minute?: number;
+  task_date?: string; // ISO date string e.g., "YYYY-MM-DD"
+}
+
+// Zod schema for validating createTask parameters
+const CreateTaskParamsSchema = z.object({
+  title: z.string().min(1, { message: "Title is required and cannot be empty." }),
+  description: z.string().optional(),
+  estimated_minute: z.number().int().gte(0, { message: "Estimated minutes must be a non-negative integer." }).optional(),
+  task_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, { message: "Task date must be in YYYY-MM-DD format." }).optional(),
+});
+
+// Tool definitions
+const CREATE_TASK_TOOL_NAME = 'create_task';
+const CREATE_TASK_TOOL_DESCRIPTION = 'Creates a new task in Supabase via the task-management function.';
+
+// Core logic for the createTask tool
+const createTaskToolLogic = async (params: CreateTaskParams) => { // Type params as CreateTaskParams; Zod validation happens at the start of this function
+  console.log(`[${new Date().toISOString()}] MCP Tool '${CREATE_TASK_TOOL_NAME}' called with raw params:`, params);
+
+  let validatedParams: CreateTaskParams;
+  try {
+    validatedParams = CreateTaskParamsSchema.parse(params); // params are validated here
+    console.log(`[${new Date().toISOString()}] Validated params for '${CREATE_TASK_TOOL_NAME}':`, validatedParams);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      console.error(`[${new Date().toISOString()}] Invalid parameters for '${CREATE_TASK_TOOL_NAME}' tool:`, error.flatten().fieldErrors);
+      const errorSummary = Object.entries(error.flatten().fieldErrors)
+        .map(([field, messages]) => `${field}: ${messages?.join(', ')}`)
+        .join('; ');
+      // This error will be caught by the CallTool handler and propagated
+      throw new Error(`Invalid parameters for ${CREATE_TASK_TOOL_NAME}: ${errorSummary}`);
+    }
+    console.error(`[${new Date().toISOString()}] Unexpected error during parameter validation for '${CREATE_TASK_TOOL_NAME}':`, error);
+    throw new Error('An unexpected error occurred during parameter validation.');
+  }
+  
+  const body = {
+    title: validatedParams.title,
+    description: validatedParams.description,
+    estimated_minute: validatedParams.estimated_minute,
+    task_date: validatedParams.task_date,
+  };
+
+  try {
+    console.log(`[${new Date().toISOString()}] Forwarding request to Supabase function: ${supabaseFunctionUrl} with body:`, body);
+    const response = await fetch(supabaseFunctionUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-integration-id': integrationId,
+      },
+      body: JSON.stringify(body),
+    });
+
+    let responseBody;
+    try {
+      responseBody = await response.json();
+    } catch (parseError) {
+      console.error(`[${new Date().toISOString()}] Error parsing JSON response from Supabase:`, parseError);
+      if (!response.ok) {
+        throw new Error(`Supabase function returned non-OK status ${response.status} and non-JSON/empty response.`);
+      }
+      throw new Error(`Supabase function returned OK status but failed to parse JSON response: ${parseError}`);
+    }
+    
+    console.log(`[${new Date().toISOString()}] Received response from Supabase: ${response.status}`, responseBody);
+
+    if (!response.ok) {
+      console.error(`[${new Date().toISOString()}] Supabase function returned an error: ${response.status}`, responseBody);
+      const errorMessage = (responseBody && typeof responseBody === 'object' && 'message' in responseBody) 
+        ? (responseBody as { message: string }).message 
+        : JSON.stringify(responseBody);
+      throw new Error(`Error from Supabase: ${response.status} - ${errorMessage}`);
+    }
+    
+    console.log(`[${new Date().toISOString()}] Task created successfully via Supabase:`, responseBody);
+    return responseBody;
+  } catch (error: any) { // Errors from fetch or Supabase logic
+    console.error(`[${new Date().toISOString()}] Error in '${CREATE_TASK_TOOL_NAME}' tool logic execution:`, error);
+    if (error instanceof Error) {
+        throw error; 
+    }
+    throw new Error(`An unknown error occurred within the ${CREATE_TASK_TOOL_NAME} tool execution.`);
+  }
+};
+
+// --- MCP Request Handlers ---
+
+// ListTools Handler
+server.setRequestHandler(ListToolsRequestSchema, async (_request) => {
+  console.log(`[${new Date().toISOString()}] Handling ListTools request.`);
+  const createTaskInputJsonSchema = zodToJsonSchema(CreateTaskParamsSchema, "CreateTaskParamsSchema");
+
+  return {
+    tools: [
+      {
+        name: CREATE_TASK_TOOL_NAME,
+        description: CREATE_TASK_TOOL_DESCRIPTION,
+        inputSchema: createTaskInputJsonSchema,
+      },
+    ],
+  };
+});
+
+// CallTool Handler
+server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
+  // Assuming request is an object with toolName and parameters.
+  // For stricter validation, parse 'request' with CallToolRequestSchema if it's a Zod schema.
+  // E.g., const validatedRequest = CallToolRequestSchema.parse(request);
+  // const { toolName, parameters } = validatedRequest;
+  
+  const toolName = request.toolName;
+  const parameters = request.parameters; // These parameters are passed to the specific tool logic
+
+  console.log(`[${new Date().toISOString()}] Handling CallTool request for tool: '${toolName}' with parameters:`, parameters);
+
+  try {
+    switch (toolName) {
+      case CREATE_TASK_TOOL_NAME:
+        // createTaskToolLogic itself handles Zod validation of its parameters
+        return await createTaskToolLogic(parameters);
+      // Cases for other tools would go here
+      default:
+        console.error(`[${new Date().toISOString()}] Unknown tool called: '${toolName}'`);
+        throw new Error(`Tool '${toolName}' not found.`);
+    }
+  } catch (error: any) {
+    // This catches errors from tool logic (including Zod validation errors within them) or the switch statement.
+    console.error(`[${new Date().toISOString()}] Error during execution of tool '${toolName}':`, error.message);
+    // Re-throw the error so McpServer can handle it and relay to the client.
+    // Ensure it's an Error instance.
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error(`An unexpected error occurred while executing tool '${toolName}': ${error}`);
+  }
+});
+
+console.log(`[${new Date().toISOString()}] MCP Server with StdioTransport started. Ready to handle ListTools and CallTool requests.`);
+
+[end of mcp/index.ts]

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -9,20 +9,64 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.11.3",
-        "zod": "^3.24.4"
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "node-fetch": "^2.7.0",
+        "zod": "^3.24.4",
+        "zod-to-json-schema": "^3.24.5"
+      },
+      "bin": {
+        "mcp": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.15.18",
+        "@types/node": "^22.15.24",
+        "@types/node-fetch": "^2.6.12",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.11.3.tgz",
-      "integrity": "sha512-rmOWVRUbUJD7iSvJugjUbFZshTAuJ48MXoZ80Osx1GM0K/H1w7rSEvmw8m6vdWxNASgtaHIhAgre4H/E9GJiYQ==",
-      "license": "MIT",
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.0.tgz",
+      "integrity": "sha512-m//7RlINx1F3sz3KqwY1WWzVgTcYX52HYk4bJ1hkBXV3zccAEth+jRvG8DBRrdaQuRsPAJOx2MH3zaHNCKL7Zg==",
+      "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
@@ -38,14 +82,47 @@
         "node": ">=18"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.24.tgz",
+      "integrity": "sha512-w9CZGm9RDjzTh/D+hFwlBJ3ziUaVw7oufKA3vOFSOZlzmW9AkZnfjPb+DLnrV6qtgL/LNmP0/2zBNCFHL3F0ng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/accepts": {
@@ -60,6 +137,57 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -119,6 +247,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
@@ -171,6 +311,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -202,6 +348,15 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -209,6 +364,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -265,6 +429,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -363,6 +542,16 @@
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -378,6 +567,42 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -468,6 +693,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -535,6 +775,17 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -599,6 +850,25 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -690,6 +960,14 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -927,6 +1205,54 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -946,7 +1272,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -971,6 +1296,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -978,6 +1317,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -1001,6 +1354,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/zod": {
       "version": "3.24.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
@@ -1014,7 +1376,6 @@
       "version": "3.24.5",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,12 +2,11 @@
   "name": "mcp",
   "version": "1.0.0",
   "main": "index.js",
-  "type": "module",
   "bin": {
-    "mcp": "./build/index.js"
+    "mcp": "build/index.js"
   },
   "scripts": {
-    "build": "tsc && chmod 755 build/index.js",
+    "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "files": [
@@ -16,13 +15,17 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": "",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.11.3",
-    "zod": "^3.24.4"
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "node-fetch": "^2.7.0",
+    "zod": "^3.24.4",
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
-    "@types/node": "^22.15.18",
+    "@types/node": "^22.15.24",
+    "@types/node-fetch": "^2.6.12",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
-  }
+  },
+  "description": ""
 }

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,15 +1,21 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "outDir": "./build",
-    "rootDir": "./src",
-    "strict": true,
+    "target": "ES2020",
+    "module": "commonjs",
     "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "outDir": "./dist",
+    "rootDir": "./",
+    "resolveJsonModule": true,
+    "moduleResolution": "node"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "include": [
+    "*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Reverts the environment variable name used for the Supabase integration identifier from `X_INTEGRATION_KEY` back to `X_INTEGRATION_ID`.

This change is applied consistently across:
- `mcp/index.ts`: The server code now reads `process.env.X_INTEGRATION_ID`.
- `mcp/README.md`: All documentation, examples, and client configuration snippets now refer to `X_INTEGRATION_ID`.

The actual HTTP header sent to the Supabase function remains `x-integration-id`. This commit corrects a previous change and aligns with your definitive requirement for the environment variable name.