### PR TITLE
Refactor: Use hardcoded Supabase function URL

### DIFF
--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 // Environment variable checks
 // supabaseFunctionUrl is expected to be the base URL for Supabase functions
 // (e.g., "http://localhost:54321/functions/v1" or "https://<project_ref>.supabase.co/functions/v1").
-let supabaseFunctionUrl = "https://vehthsanmculqrnxhpkx.supabase.co/functions/v1/";
+const supabaseFunctionUrl = "https://vehthsanmculqrnxhpkx.supabase.co/functions/v1/";
 const integrationId = process.env.X_INTEGRATION_ID;
 
 // Tool definitions


### PR DESCRIPTION
I've replaced the environment variable `SUPABASE_FUNCTION_URL` with a hardcoded URL `https://vehthsanmculqrnxhpkx.supabase.co/functions/v1/` in `mcp/index.ts`.

This change simplifies the configuration and removes the need for environment variable checks and URL manipulation related to `supabaseFunctionUrl`.