### PR TITLE
Fix: Add user_id to last_used_at update for RLS

### DIFF
--- a/supabase/functions/search-tasks-per-day/index.ts
+++ b/supabase/functions/search-tasks-per-day/index.ts
@@ -148,7 +148,7 @@ export const handler = async (req: Request): Promise<Response> => {
       .from("integration_keys")
       .update({ last_used_at: new Date().toISOString() })
       .eq("key", integrationId)
-      .eq("user_id", actualUserId); // <== ADD THIS CONDITION
+      .eq("user_id", keyData.user_id); // <== ADD THIS CONDITION
 
     if (updateError) {
       console.error("Error updating last_used_at for integration key:", updateError);

--- a/supabase/functions/search-tasks-per-day/index.ts
+++ b/supabase/functions/search-tasks-per-day/index.ts
@@ -142,6 +142,24 @@ export const handler = async (req: Request): Promise<Response> => {
     );
   }
 
+  // ==> ADD THE UPDATE LOGIC HERE <==
+  try {
+    const { error: updateError } = await serviceRoleClient
+      .from("integration_keys")
+      .update({ last_used_at: new Date().toISOString() })
+      .eq("key", integrationId)
+      .eq("user_id", actualUserId); // <== ADD THIS CONDITION
+
+    if (updateError) {
+      console.error("Error updating last_used_at for integration key:", updateError);
+      // Non-critical error, so we don't return. Log and continue.
+    }
+  } catch (e) {
+      console.error("Exception during last_used_at update for integration key:", e.message);
+      // Non-critical error, so we don't return. Log and continue.
+  }
+  // ==> END OF ADDED LOGIC <==
+
   // Generate JWT
   const actualUserId = keyData.user_id;
   let token;

--- a/supabase/functions/task-management/index.ts
+++ b/supabase/functions/task-management/index.ts
@@ -216,7 +216,7 @@ Deno.serve(async (req) => {
         .from("integration_keys")
         .update({ last_used_at: new Date().toISOString() })
         .eq("key", integrationId)
-        .eq("user_id", actualUserId); // <== ADD THIS CONDITION
+        .eq("user_id", keyData.user_id); // <== ADD THIS CONDITION
 
       if (updateError) {
         console.error("Error updating last_used_at for integration key:", updateError);

--- a/supabase/functions/task-management/index.ts
+++ b/supabase/functions/task-management/index.ts
@@ -210,6 +210,24 @@ Deno.serve(async (req) => {
       );
     }
 
+    // ==> ADD THE UPDATE LOGIC HERE <==
+    try {
+      const { error: updateError } = await serviceRoleClient
+        .from("integration_keys")
+        .update({ last_used_at: new Date().toISOString() })
+        .eq("key", integrationId)
+        .eq("user_id", actualUserId); // <== ADD THIS CONDITION
+
+      if (updateError) {
+        console.error("Error updating last_used_at for integration key:", updateError);
+        // Non-critical error, so we don't return. Log and continue.
+      }
+    } catch (e) {
+        console.error("Exception during last_used_at update for integration key:", e.message);
+        // Non-critical error, so we don't return. Log and continue.
+    }
+    // ==> END OF ADDED LOGIC <==
+
     const actualUserId = keyData.user_id;
 
     let token;


### PR DESCRIPTION
This commit updates the logic for updating the `last_used_at` timestamp in the `integration_keys` table to be more precise by including the `user_id` in the filter criteria.

This change affects the following edge functions:
- `supabase/functions/search-tasks-per-day/index.ts`
- `supabase/functions/task-management/index.ts`

Previously, the update to `last_used_at` was based solely on the `integrationId` (`key`). While `serviceRoleClient` typically bypasses RLS, explicitly adding `.eq("user_id", actualUserId)` to the update operation ensures that the update is correctly scoped to the specific user associated with the key, aligning better with RLS policies and improving robustness. The `actualUserId` is derived from the initial fetch of the integration key.