### PR TITLE
Fix time parsing

### DIFF
--- a/ui/src/lib/utils.test.ts
+++ b/ui/src/lib/utils.test.ts
@@ -79,6 +79,10 @@ describe("parseTimeInputToISOString", () => {
     expect(parseTimeInputToISOString("12:345", baseDate)).toBeNull();
   });
 
+  it('should return null for invalid format "12:34:56" (too many colons)', () => {
+    expect(parseTimeInputToISOString("12:34:56", baseDate)).toBeNull();
+  });
+
   it('should return null for invalid hour "2500"', () => {
     expect(parseTimeInputToISOString("2500", baseDate)).toBeNull();
   });

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -15,8 +15,18 @@ export const parseTimeInputToISOString = (
     let minutes: number;
 
     if (textInput.includes(":")) {
-      // 「13:45」形式
-      const [h, m] = textInput.split(":");
+      // 「13:45」形式。コロンは1つだけ、分は必ず2桁
+      const parts = textInput.split(":");
+      if (
+        parts.length !== 2 ||
+        parts[0] === "" ||
+        parts[1].length !== 2 ||
+        !/^\d+$/.test(parts[0]) ||
+        !/^\d+$/.test(parts[1])
+      ) {
+        return null;
+      }
+      const [h, m] = parts;
       hours = parseInt(h);
       minutes = parseInt(m);
     } else if (textInput.includes("時")) {


### PR DESCRIPTION
## Summary
- add strict validation of colon-separated times
- reject multiple colons in `parseTimeInputToISOString`
- test new invalid case

## Testing
- `npx vitest run`
- `npm --prefix ui run lint`

------
https://chatgpt.com/codex/tasks/task_e_684042195aa48329bba1ea5c56e1d0e8